### PR TITLE
propagate namespace throughout supervision tree

### DIFF
--- a/lib/vitals.ex
+++ b/lib/vitals.ex
@@ -1,9 +1,13 @@
 defmodule Vitals do
-  @spec check_diagnostics() :: String.t()
+  @moduledoc false
+  @spec check_diagnostics() :: String.t() | integer()
   def check_diagnostics() do
     Vitals.DiagnosticTable.check_diagnostics(:pretty)
   end
 
-  @spec check_diagnostics(Vitals.Formatter.format()) :: String.t()
-  defdelegate check_diagnostics(format), to: Vitals.DiagnosticTable
+  @spec check_diagnostics(Vitals.Formatter.format()) :: String.t() | integer()
+  def check_diagnostics(format, opts \\ []) do
+    opts = Keyword.put_new(opts, :name, __MODULE__)
+    Vitals.DiagnosticTable.check_diagnostics(format, opts)
+  end
 end

--- a/lib/vitals/dummy.ex
+++ b/lib/vitals/dummy.ex
@@ -7,8 +7,6 @@ defmodule Vitals.DummyHandler do
   end
 
   def init(spec) do
-    dbg(spec.id)
-
     status =
       if spec.id == "handler1" do
         :degraded

--- a/lib/vitals/handler_supervisor.ex
+++ b/lib/vitals/handler_supervisor.ex
@@ -5,14 +5,14 @@ defmodule Vitals.HandlerSupervisor do
 
   use Supervisor
 
-  def start_link(handlers) do
-    Supervisor.start_link(__MODULE__, handlers, name: __MODULE__)
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts, name: Module.concat(opts[:name], HandlerSupervisor))
   end
 
-  def init(handlers) do
-    handlers
+  def init(opts) do
+    opts[:handlers]
     |> Enum.map(fn handler_spec ->
-      {Vitals.DiagnosticServer, handler_spec}
+      {Vitals.DiagnosticServer, handler_spec: handler_spec, name: opts[:name]}
     end)
     |> Supervisor.init(strategy: :one_for_one)
   end

--- a/lib/vitals/supervisor.ex
+++ b/lib/vitals/supervisor.ex
@@ -4,6 +4,7 @@ defmodule Vitals.Supervisor do
   # in application.ex or root supervisor
   {
     Vitals.Supervisor,
+    name: MyVitals,
     handlers: [
       Vitals.Handler.spec(
         id: "ecto"
@@ -24,8 +25,10 @@ defmodule Vitals.Supervisor do
   use Supervisor
 
   def start_link(opts) do
+    opts = Keyword.put_new(opts, :name, Vitals)
+
     if handlers_valid?(opts[:handlers]) do
-      Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+      Supervisor.start_link(__MODULE__, opts, name: Module.concat(opts[:name], Supervisor))
     else
       raise ArgumentError, "Each Vitals.Handler.Spec must have unique id"
     end
@@ -35,8 +38,8 @@ defmodule Vitals.Supervisor do
     handlers = opts[:handlers]
 
     children = [
-      {Vitals.DiagnosticTable, handlers},
-      {Vitals.HandlerSupervisor, handlers}
+      {Vitals.DiagnosticTable, handlers: handlers, name: opts[:name]},
+      {Vitals.HandlerSupervisor, handlers: handlers, name: opts[:name]}
     ]
 
     Supervisor.init(children, strategy: :one_for_all)


### PR DESCRIPTION
In order to accomodate testing, we need to allow for end users to provide a separate supervision stack. To accomodate this, modify opts to pass name throughout the supervision tree optionally, or default to Vitals namespace.